### PR TITLE
Remove `zenoh-jni` Debian package 

### DIFF
--- a/zenoh-jni/Cargo.toml
+++ b/zenoh-jni/Cargo.toml
@@ -47,11 +47,6 @@ crate_type = ["staticlib", "dylib"]
 [build-dependencies]
 rustc_version = "0.4.0"
 
-[package.metadata.deb]
-name = "zenoh_jni"
-maintainer = "zenoh@zettascale.tech"
-copyright = "2023 ZettaScale Technology"
-
 [profile.release]
 debug = false     # If you want debug symbol in release mode, set the env variable: RUSTFLAGS=-g
 lto = "fat"


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/zenoh-kotlin/issues/38.