### PR TITLE
feat(user_attachment): user attachment implementation

### DIFF
--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -25,6 +25,7 @@ import io.zenoh.publication.Put
 import io.zenoh.query.*
 import io.zenoh.queryable.Query
 import io.zenoh.queryable.Queryable
+import io.zenoh.sample.Attachment
 import io.zenoh.sample.Sample
 import io.zenoh.selector.Selector
 import io.zenoh.subscriber.Reliability
@@ -387,12 +388,13 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         timeout: Duration,
         target: QueryTarget,
         consolidation: ConsolidationMode,
-        value: Value?
+        value: Value?,
+        attachment: Attachment?,
     ): R? {
         if (jniSession == null) {
             throw sessionClosedException
         }
-        return jniSession?.performGet(selector, callback, onClose, receiver, timeout, target, consolidation, value)
+        return jniSession?.performGet(selector, callback, onClose, receiver, timeout, target, consolidation, value, attachment)
     }
 
     @Throws(ZenohException::class)

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/JNIQuery.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/JNIQuery.kt
@@ -38,6 +38,7 @@ internal class JNIQuery(private val ptr: Long) {
             sample.kind.ordinal,
             timestampEnabled,
             if (timestampEnabled) sample.timestamp!!.ntpValue() else 0,
+            sample.attachment?.let { encodeAttachment(it) },
         )
     }
 
@@ -58,7 +59,8 @@ internal class JNIQuery(private val ptr: Long) {
         valueEncoding: Int,
         sampleKind: Int,
         timestampEnabled: Boolean,
-        timestampNtp64: Long
+        timestampNtp64: Long,
+        attachment: ByteArray?,
     )
 
     @Throws(ZenohException::class)

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/JNIUtils.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/JNIUtils.kt
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.jni
+
+import io.zenoh.sample.Attachment
+
+/**
+ * Encode attachment as a byte array.
+ */
+internal fun encodeAttachment(attachment: Attachment): ByteArray {
+    return attachment.values.map {
+        val key = it.first
+        val keyLength = key.size.toByteArray()
+        val value = it.second
+        val valueLength = value.size.toByteArray()
+        keyLength + key + valueLength + value
+    }.reduce { acc, bytes -> acc + bytes }
+}
+
+/**
+ * Decode an attachment as a byte array, recreating the original [Attachment].
+ */
+internal fun decodeAttachment(attachmentBytes: ByteArray): Attachment {
+    var idx = 0
+    var sliceSize: Int
+    val pairs: MutableList<Pair<ByteArray, ByteArray>> = mutableListOf()
+    while (idx < attachmentBytes.size) {
+        sliceSize = attachmentBytes.sliceArray(IntRange(idx, idx + Int.SIZE_BYTES - 1)).toInt()
+        idx += Int.SIZE_BYTES
+
+        val key = attachmentBytes.sliceArray(IntRange(idx, idx + sliceSize - 1))
+        idx += sliceSize
+
+        sliceSize = attachmentBytes.sliceArray(IntRange(idx, idx + Int.SIZE_BYTES - 1)).toInt()
+        idx += Int.SIZE_BYTES
+
+        val value = attachmentBytes.sliceArray(IntRange(idx, idx + sliceSize - 1))
+        idx += sliceSize
+
+        pairs.add(key to value)
+    }
+    return Attachment(pairs)
+}
+
+/**
+ * Converts an integer into a byte array with little endian format.
+ */
+fun Int.toByteArray(): ByteArray {
+    val result = ByteArray(UInt.SIZE_BYTES)
+    (0 until UInt.SIZE_BYTES).forEach {
+        result[it] = this.shr(Byte.SIZE_BITS * it).toByte()
+    }
+    return result
+}
+
+/**
+ * To int. The byte array is expected to be in Little Endian format.
+ *
+ * @return The integer value.
+ */
+fun ByteArray.toInt(): Int =
+    (((this[3].toUInt() and 0xFFu) shl 24) or ((this[2].toUInt() and 0xFFu) shl 16) or ((this[1].toUInt() and 0xFFu) shl 8) or (this[0].toUInt() and 0xFFu)).toInt()

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
@@ -24,6 +24,7 @@ internal fun interface JNIGetCallback {
         encoding: Int,
         kind: Int,
         timestampNTP64: Long,
-        timestampIsValid: Boolean
+        timestampIsValid: Boolean,
+        attachment: ByteArray,
     )
 }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIQueryableCallback.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIQueryableCallback.kt
@@ -20,5 +20,6 @@ internal fun interface JNIQueryableCallback {
             withValue: Boolean,
             payload: ByteArray?,
             encoding: Int,
+            attachmentBytes: ByteArray,
             queryPtr: Long)
 }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNISubscriberCallback.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNISubscriberCallback.kt
@@ -21,6 +21,7 @@ internal fun interface JNISubscriberCallback {
         encoding: Int,
         kind: Int,
         timestampNTP64: Long,
-        timestampIsValid: Boolean
+        timestampIsValid: Boolean,
+        attachment: ByteArray,
     )
 }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/publication/Delete.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/publication/Delete.kt
@@ -46,7 +46,7 @@ class Delete private constructor(
     congestionControl: CongestionControl,
     priority: Priority,
     kind: SampleKind
-) : Put(keyExpr, value, congestionControl, priority, kind) {
+) : Put(keyExpr, value, congestionControl, priority, kind, null) {
 
     companion object {
         /**

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/publication/Put.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/publication/Put.kt
@@ -20,6 +20,7 @@ import io.zenoh.exceptions.ZenohException
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.prelude.Encoding
 import io.zenoh.prelude.SampleKind
+import io.zenoh.sample.Attachment
 import io.zenoh.value.Value
 
 /**
@@ -49,13 +50,15 @@ import io.zenoh.value.Value
  * @property congestionControl The [CongestionControl] to be applied when routing the data.
  * @property priority The [Priority] of zenoh messages.
  * @property kind The [SampleKind] of the sample (put or delete).
+ * @property attachment An optional user [Attachment].
  */
 open class Put protected constructor(
     val keyExpr: KeyExpr,
     val value: Value,
     val congestionControl: CongestionControl,
     val priority: Priority,
-    val kind: SampleKind
+    val kind: SampleKind,
+    val attachment: Attachment?
 ) {
 
     companion object {
@@ -91,7 +94,8 @@ open class Put protected constructor(
         private var value: Value,
         private var congestionControl: CongestionControl = CongestionControl.DROP,
         private var priority: Priority = Priority.DATA,
-        private var kind: SampleKind = SampleKind.PUT
+        private var kind: SampleKind = SampleKind.PUT,
+        private var attachment: Attachment? = null
     ): Resolvable<Unit> {
 
         /** Change the [Encoding] of the written data. */
@@ -109,10 +113,13 @@ open class Put protected constructor(
         /** Change the [SampleKind] of the sample. If set to [SampleKind.DELETE], performs a delete operation. */
         fun kind(kind: SampleKind) = apply { this.kind = kind }
 
+        /** Set an attachment to the put operation. */
+        fun withAttachment(attachment: Attachment) = apply { this.attachment = attachment }
+
         /** Resolves the put operation. */
         @Throws(ZenohException::class)
         override fun res() {
-            val put = Put(keyExpr, value, congestionControl, priority, kind)
+            val put = Put(keyExpr, value, congestionControl, priority, kind, attachment)
             session.run { resolvePut(keyExpr, put) }
         }
     }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/query/Get.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/query/Get.kt
@@ -19,6 +19,7 @@ import io.zenoh.Session
 import io.zenoh.exceptions.ZenohException
 import io.zenoh.handlers.BlockingQueueHandler
 import io.zenoh.handlers.Handler
+import io.zenoh.sample.Attachment
 import io.zenoh.selector.Selector
 import io.zenoh.value.Value
 import java.time.Duration
@@ -83,6 +84,7 @@ class Get<R> private constructor() {
         private var target: QueryTarget = QueryTarget.BEST_MATCHING
         private var consolidation: ConsolidationMode = ConsolidationMode.NONE
         private var value: Value? = null
+        private var attachment: Attachment? = null
         private var onClose: (() -> Unit)? = null
 
         private constructor(other: Builder<*>, handler: Handler<Reply, R>?) : this(other.session, other.selector) {
@@ -100,6 +102,7 @@ class Get<R> private constructor() {
             this.target = other.target
             this.consolidation = other.consolidation
             this.value = other.value
+            this.attachment = other.attachment
             this.onClose = other.onClose
         }
 
@@ -133,6 +136,12 @@ class Get<R> private constructor() {
         /** Specify a [Value]. */
         fun withValue(value: Value): Builder<R> {
             this.value = value
+            return this
+        }
+
+        /** Specify an [Attachment]. */
+        fun withAttachment(attachment: Attachment): Builder<R> {
+            this.attachment = attachment
             return this
         }
 
@@ -177,7 +186,8 @@ class Get<R> private constructor() {
                     timeout,
                     target,
                     consolidation,
-                    value
+                    value,
+                    attachment
                 )
             }
         }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/query/Reply.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/query/Reply.kt
@@ -22,6 +22,7 @@ import io.zenoh.prelude.SampleKind
 import io.zenoh.value.Value
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.queryable.Query
+import io.zenoh.sample.Attachment
 import org.apache.commons.net.ntp.TimeStamp
 
 /**
@@ -109,6 +110,7 @@ abstract class Reply private constructor(val replierId: String) : ZenohType {
 
             private var kind = SampleKind.PUT
             private var timeStamp: TimeStamp? = null
+            private var attachment: Attachment? = null
 
             /**
              * Sets the [SampleKind] of the replied [Sample].
@@ -121,11 +123,16 @@ abstract class Reply private constructor(val replierId: String) : ZenohType {
             fun withTimeStamp(timeStamp: TimeStamp) = apply { this.timeStamp = timeStamp }
 
             /**
+             * Appends an [Attachment] to the reply.
+             */
+            fun withAttachment(attachment: Attachment) = apply { this.attachment = attachment }
+
+            /**
              * Constructs the reply sample with the provided parameters and triggers the reply to the query.
              */
             @Throws(ZenohException::class)
             override fun res() {
-                val sample = Sample(keyExpr, value, kind, timeStamp)
+                val sample = Sample(keyExpr, value, kind, timeStamp, attachment)
                 return query.reply(Success("", sample)).res()
             }
         }

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/queryable/Query.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/queryable/Query.kt
@@ -23,6 +23,7 @@ import io.zenoh.exceptions.ZenohException
 import io.zenoh.jni.JNIQuery
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.query.Reply
+import io.zenoh.sample.Attachment
 
 /**
  * Represents a Zenoh Query in Kotlin.
@@ -32,6 +33,7 @@ import io.zenoh.query.Reply
  * @property keyExpr The key expression to which the query is associated.
  * @property selector The selector
  * @property value Optional value in case the received query was declared using "with query".
+ * @property attachment Optional [Attachment].
  * @property jniQuery Delegate object in charge of communicating with the underlying native code.
  * @constructor Instances of Query objects are only meant to be created through the JNI upon receiving
  * a query request. Therefore, the constructor is private.
@@ -40,6 +42,7 @@ class Query internal constructor(
     val keyExpr: KeyExpr,
     val selector: Selector,
     val value: Value?,
+    val attachment: Attachment?,
     private var jniQuery: JNIQuery?
 ) : AutoCloseable, ZenohType {
 

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Attachment.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Attachment.kt
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.sample
+
+/**
+ * Attachment
+ *
+ * An attachment consists of a list of non-unique ordered key value pairs, where keys are UTF-8 Strings and the values are bytes.
+ * Inserting at the same key multiple times leads to both values being transmitted for that key.
+ *
+ * Attachments can be added to a message sent through Zenoh while performing puts, queries and replies.
+ *
+ * Using attachments will result in performance loss.
+ *
+ * @property values
+ * @constructor Create empty Attachment
+ */
+class Attachment internal constructor(val values: List<Pair<ByteArray, ByteArray>>) {
+
+    class Builder {
+
+        private val values: MutableList<Pair<ByteArray, ByteArray>> = mutableListOf()
+
+        fun add(key: ByteArray, value: ByteArray) = apply {
+            values.add(key to value)
+        }
+
+        fun add(key: String, value: ByteArray) = apply {
+            values.add(key.toByteArray() to value)
+        }
+
+        fun add(key: String, value: String) = apply {
+            values.add(key.toByteArray() to value.toByteArray())
+        }
+
+        fun addAll(elements: Collection<Pair<ByteArray, ByteArray>>) {
+            values.addAll(elements)
+        }
+
+        fun addAll(elements: Iterable<Pair<ByteArray, ByteArray>>) {
+            values.addAll(elements)
+        }
+
+        fun res(): Attachment {
+            return Attachment(values)
+        }
+    }
+}

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Sample.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Sample.kt
@@ -30,12 +30,14 @@ import org.apache.commons.net.ntp.TimeStamp
  * @property value The [Value] of the sample.
  * @property kind The [SampleKind] of the sample.
  * @property timestamp Optional [TimeStamp].
+ * @property attachment Optional [Attachment].
  */
 class Sample(
     val keyExpr: KeyExpr,
     val value: Value,
     val kind: SampleKind,
-    val timestamp: TimeStamp?
+    val timestamp: TimeStamp?,
+    val attachment: Attachment? = null
 ): ZenohType {
     override fun toString(): String {
         return if (kind == SampleKind.DELETE) "$kind($keyExpr)" else "$kind($keyExpr: $value)"

--- a/zenoh-java/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
+++ b/zenoh-java/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
@@ -1,0 +1,274 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import io.zenoh.jni.decodeAttachment
+import io.zenoh.jni.encodeAttachment
+import io.zenoh.jni.toByteArray
+import io.zenoh.jni.toInt
+import io.zenoh.keyexpr.intoKeyExpr
+import io.zenoh.prelude.Encoding
+import io.zenoh.prelude.KnownEncoding
+import io.zenoh.prelude.SampleKind
+import io.zenoh.query.Reply
+import io.zenoh.sample.Attachment
+import io.zenoh.sample.Sample
+import io.zenoh.value.Value
+import java.time.Duration
+import kotlin.test.*
+
+class UserAttachmentTest {
+
+    companion object {
+        val value = Value("test", Encoding(KnownEncoding.TEXT_PLAIN))
+        val keyExpr = "example/testing/attachment".intoKeyExpr()
+        val attachmentPairs = arrayListOf(
+            "key1" to "value1", "key2" to "value2", "key3" to "value3", "repeatedKey" to "value1", "repeatedKey" to "value2"
+        )
+        val attachment =
+            Attachment(attachmentPairs.map { it.first.encodeToByteArray() to it.second.encodeToByteArray() })
+    }
+
+    private fun assertAttachmentOk(attachment: Attachment?) {
+        assertNotNull(attachment)
+        val receivedPairs = attachment.values
+        assertEquals(attachmentPairs.size, receivedPairs.size)
+        for ((index, receivedPair) in receivedPairs.withIndex()) {
+            assertEquals(attachmentPairs[index].first, receivedPair.first.decodeToString())
+            assertEquals(attachmentPairs[index].second, receivedPair.second.decodeToString())
+        }
+    }
+
+    @Test
+    fun putWithAttachmentTest() {
+        var receivedSample: Sample? = null
+        val session = Session.open()
+
+        val subscriber = session.declareSubscriber(keyExpr).with { sample -> receivedSample = sample }.res()
+        session.put(keyExpr, value).withAttachment(attachment).res()
+
+        Thread.sleep(500)
+
+        subscriber.close()
+        session.close()
+
+        assertNotNull(receivedSample)
+        assertEquals(value, receivedSample!!.value)
+        assertAttachmentOk(receivedSample!!.attachment)
+    }
+
+    @Test
+    fun publisherPutWithAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+
+        publisher.put("test").withAttachment(attachment).res()
+        publisher.close()
+        subscriber.close()
+        session.close()
+
+        assertAttachmentOk(receivedSample!!.attachment!!)
+    }
+
+    @Test
+    fun publisherPutWithoutAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+        publisher.put("test").res()
+
+        Thread.sleep(1000)
+
+        subscriber.close()
+        publisher.close()
+        session.close()
+
+        assertNotNull(receivedSample)
+        assertNull(receivedSample!!.attachment)
+    }
+
+    @Test
+    fun publisherWriteWithAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+
+        publisher.write(SampleKind.PUT, Value("test")).withAttachment(attachment).res()
+        Thread.sleep(500)
+
+        subscriber.close()
+        publisher.close()
+        session.close()
+
+        assertAttachmentOk(receivedSample!!.attachment!!)
+    }
+
+    @Test
+    fun publisherWriteWithoutAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+
+        publisher.write(SampleKind.PUT, Value("test")).res()
+
+        Thread.sleep(500)
+
+        publisher.close()
+        subscriber.close()
+        session.close()
+
+        assertNotNull(receivedSample)
+        assertNull(receivedSample!!.attachment)
+    }
+
+    @Test
+    fun publisherDeleteWithAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+
+        publisher.delete().withAttachment(attachment).res()
+
+        Thread.sleep(500)
+        subscriber.close()
+        publisher.close()
+        session.close()
+
+        assertAttachmentOk(receivedSample!!.attachment!!)
+    }
+
+    @Test
+    fun publisherDeleteWithoutAttachmentTest() {
+        val session = Session.open()
+
+        var receivedSample: Sample? = null
+        val publisher = session.declarePublisher(keyExpr).res()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample ->
+            receivedSample = sample
+        }.res()
+
+        publisher.delete().res()
+
+        subscriber.close()
+        publisher.close()
+        session.close()
+
+        assertNotNull(receivedSample)
+        assertNull(receivedSample!!.attachment)
+    }
+
+    @Test
+    fun queryWithAttachmentTest() {
+        val session = Session.open()
+
+        var receivedAttachment: Attachment? = null
+
+        val queryable = session.declareQueryable(keyExpr).with { query ->
+            receivedAttachment = query.attachment
+            query.reply(keyExpr).success("test").res()
+        }.res()
+
+        session.get(keyExpr).with {}.withAttachment(attachment).timeout(Duration.ofMillis(1000)).res()
+        Thread.sleep(1000)
+
+        queryable.close()
+        session.close()
+        assertAttachmentOk(receivedAttachment)
+    }
+
+    @Test
+    fun queryReplyWithAttachmentTest() {
+        val session = Session.open()
+
+        var receivedAttachment: Attachment? = null
+
+        val queryable = session.declareQueryable(keyExpr).with { query ->
+            query.reply(keyExpr).success("test").withAttachment(attachment).res()
+        }.res()
+
+        session.get(keyExpr).with { reply ->
+            (reply as Reply.Success)
+            receivedAttachment = reply.sample.attachment
+        }.timeout(Duration.ofMillis(1000)).res()
+
+        Thread.sleep(1000)
+
+        queryable.close()
+        session.close()
+        assertAttachmentOk(receivedAttachment)
+    }
+
+    @Test
+    fun queryReplyWithoutAttachmentTest() {
+        var reply: Reply? = null
+        val session = Session.open()
+        val queryable = session.declareQueryable(keyExpr).with { query ->
+            query.reply(keyExpr).success("test").res()
+        }.res()
+
+        session.get(keyExpr).with {
+            reply = it
+        }.timeout(Duration.ofMillis(1000)).res()
+
+        Thread.sleep(1000)
+
+        queryable.close()
+        session.close()
+
+        assertNotNull(reply)
+        assertTrue(reply is Reply.Success)
+        assertNull((reply as Reply.Success).sample.attachment)
+    }
+
+    @Test
+    fun encodeAndDecodeNumbersTest() {
+        val numbers: List<Int> = arrayListOf(0, 1, -1, 12345, -12345, 123567, 123456789, -123456789)
+
+        for (number in numbers) {
+            val bytes = number.toByteArray()
+            val decodedNumber: Int = bytes.toInt()
+            assertEquals(number, decodedNumber)
+        }
+    }
+
+    @Test
+    fun encodeAndDecodeAttachmentTest() {
+        val encodedAttachment = encodeAttachment(attachment)
+        val decodedAttachment = decodeAttachment(encodedAttachment)
+
+        assertAttachmentOk(decodedAttachment)
+    }
+}

--- a/zenoh-jni/src/query.rs
+++ b/zenoh-jni/src/query.rs
@@ -23,14 +23,18 @@ use zenoh::{
     prelude::{sync::SyncResolve, KeyExpr, SplitBuffer},
     query::{ConsolidationMode, QueryTarget},
     queryable::Query,
-    sample::Sample,
+    sample::{Attachment, Sample},
     value::Value,
 };
 
-use crate::sample::decode_sample;
 use crate::{
     errors::{Error, Result},
+    utils::attachment_to_vec,
     value::decode_value,
+};
+use crate::{
+    sample::decode_sample,
+    utils::{decode_byte_array, vec_to_attachment},
 };
 
 /// Replies with success to a Zenoh query via JNI.
@@ -47,6 +51,7 @@ use crate::{
 /// - `sample_kind`: The kind of sample.
 /// - `timestamp_enabled`: A boolean indicating whether the timestamp is enabled.
 /// - `timestamp_ntp_64`: The NTP64 timestamp value.
+/// - `attachment`: Optional user attachment encoded as a byte array. May be null.
 ///
 /// Safety:
 /// - This function is marked as unsafe due to raw pointer manipulation and JNI interaction.
@@ -66,6 +71,7 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
     sample_kind: jint,
     timestamp_enabled: jboolean,
     timestamp_ntp_64: jlong,
+    attachment: JByteArray,
 ) {
     let key_expr = Arc::from_raw(key_expr_ptr);
     let key_expr_clone = key_expr.deref().clone();
@@ -87,9 +93,22 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
             return;
         }
     };
+    let attachment: Option<Attachment> = if !attachment.is_null() {
+        match decode_byte_array(&env, attachment) {
+            Ok(attachment_bytes) => Some(vec_to_attachment(attachment_bytes)),
+            Err(err) => {
+                _ = err.throw_on_jvm(&mut env).map_err(|err| {
+                    log::error!("Unable to throw exception on query reply failure. {}", err)
+                });
+                return;
+            }
+        }
+    } else {
+        None
+    };
 
     let query = Arc::from_raw(query_ptr);
-    query_reply(&query, Ok(sample), env);
+    query_reply(env, &query, Ok(sample), attachment);
     mem::forget(query)
 }
 
@@ -109,6 +128,7 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
 /// - `key_expr`: The key expression associated with the query result.
 /// - `payload`: The payload as a `JByteArray`.
 /// - `encoding`: The encoding of the payload as a jint.
+/// - `attachment`: The user attachment bytes.
 ///
 /// Safety:
 /// - This function is marked as unsafe due to raw pointer manipulation and JNI interaction.
@@ -124,6 +144,7 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyErrorViaJNI(
     ptr: *const zenoh::queryable::Query,
     payload: JByteArray,
     encoding: jint,
+    attachment: JByteArray,
 ) {
     let errorValue = match decode_value(&env, payload, encoding) {
         Ok(value) => value,
@@ -134,9 +155,22 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyErrorViaJNI(
             return;
         }
     };
+    let attachment: Option<Attachment> = if !attachment.is_null() {
+        match decode_byte_array(&env, attachment) {
+            Ok(attachment_bytes) => Some(vec_to_attachment(attachment_bytes)),
+            Err(err) => {
+                _ = err.throw_on_jvm(&mut env).map_err(|err| {
+                    log::error!("Unable to throw exception on query reply failure. {}", err)
+                });
+                return;
+            }
+        }
+    } else {
+        None
+    };
 
     let query = Arc::from_raw(ptr);
-    query_reply(&query, Err(errorValue), env);
+    query_reply(env, &query, Err(errorValue), attachment);
     mem::forget(query)
 }
 
@@ -209,6 +243,17 @@ pub(crate) fn on_query(
         None => (false, JPrimitiveArray::default(), 0),
     };
 
+    let attachment_bytes = match query.attachment().map_or_else(
+        || env.byte_array_from_slice(&[]),
+        |attachment| env.byte_array_from_slice(attachment_to_vec(attachment.clone()).as_slice()),
+    ) {
+        Ok(byte_array) => Ok(byte_array),
+        Err(err) => Err(Error::Jni(format!(
+            "Error processing attachment of reply: {}.",
+            err
+        ))),
+    }?;
+
     let key_expr = query.key_expr().clone();
     let key_expr_ptr = Arc::into_raw(Arc::new(key_expr));
     let query_ptr = Arc::into_raw(Arc::new(query));
@@ -217,13 +262,14 @@ pub(crate) fn on_query(
         .call_method(
             callback_global_ref,
             "run",
-            "(JLjava/lang/String;Z[BIJ)V",
+            "(JLjava/lang/String;Z[BI[BJ)V",
             &[
                 JValue::from(key_expr_ptr as jlong),
                 JValue::from(&selector_params_jstr),
                 JValue::from(with_value),
                 JValue::from(&payload),
                 JValue::from(encoding),
+                JValue::from(&attachment_bytes),
                 JValue::from(query_ptr as jlong),
             ],
         )
@@ -251,12 +297,29 @@ pub(crate) fn on_query(
 }
 
 /// Helper function to perform a reply to a query.
-fn query_reply(query: &Arc<Query>, reply: core::result::Result<Sample, Value>, mut env: JNIEnv) {
-    match query
-        .reply(reply)
-        .res()
-        .map_err(|err| Error::Session(err.to_string()))
-    {
+fn query_reply(
+    mut env: JNIEnv,
+    query: &Arc<Query>,
+    reply: core::result::Result<Sample, Value>,
+    attachment: Option<Attachment>,
+) {
+    let result = if let Some(attachment) = attachment {
+        query
+            .reply(reply)
+            .with_attachment(attachment)
+            .unwrap_or_else(|(builder, _)| {
+                log::warn!("Unable to append attachment to query reply");
+                builder
+            })
+            .res()
+            .map_err(|err| Error::Session(err.to_string()))
+    } else {
+        query
+            .reply(reply)
+            .res()
+            .map_err(|err| Error::Session(err.to_string()))
+    };
+    match result {
         Ok(_) => {}
         Err(err) => {
             _ = err.throw_on_jvm(&mut env).map_err(|err| {

--- a/zenoh-jni/src/utils.rs
+++ b/zenoh-jni/src/utils.rs
@@ -15,9 +15,10 @@
 use std::sync::Arc;
 
 use jni::{
-    objects::{JObject, JString},
+    objects::{JByteArray, JObject, JString},
     JNIEnv, JavaVM,
 };
+use zenoh::sample::{Attachment, AttachmentBuilder};
 
 use crate::errors::{Error, Result};
 
@@ -47,6 +48,19 @@ pub(crate) fn get_callback_global_ref(
             err
         ))
     })
+}
+
+/// Helper function to convert a JByteArray into a Vec<u8>.
+pub(crate) fn decode_byte_array(env: &JNIEnv<'_>, payload: JByteArray) -> Result<Vec<u8>> {
+    let payload_len = env
+        .get_array_length(&payload)
+        .map(|length| length as usize)
+        .map_err(|err| Error::Jni(err.to_string()))?;
+    let mut buff = vec![0; payload_len];
+    env.get_byte_array_region(payload, 0, &mut buff[..])
+        .map_err(|err| Error::Jni(err.to_string()))?;
+    let buff: Vec<u8> = unsafe { std::mem::transmute::<Vec<i8>, Vec<u8>>(buff) };
+    Ok(buff)
 }
 
 /// A type that calls a function when dropped
@@ -97,4 +111,63 @@ pub(crate) fn load_on_close(
             }
         }
     })
+}
+
+/// This function is used in conjunction with the Kotlin function
+/// `decodeAttachment(attachmentBytes: ByteArray): Attachment` which takes a byte array with the
+/// format <key size><key payload><value size><value payload>, repeating this
+/// pattern for as many pairs there are in the attachment.
+///
+/// The kotlin function expects both key size and value size to be i32 integers expressed with
+/// little endian format.
+///
+pub(crate) fn attachment_to_vec(attachment: Attachment) -> Vec<u8> {
+    let mut buffer: Vec<u8> = Vec::new();
+    for (key, value) in attachment.iter() {
+        buffer.extend((key.len() as i32).to_le_bytes());
+        buffer.extend(&key[..]);
+        buffer.extend((value.len() as i32).to_le_bytes());
+        buffer.extend(&value[..]);
+    }
+    buffer
+}
+
+/// This function is used in conjunction with the Kotlin function
+/// `encodeAttachment(attachment: Attachment): ByteArray` which converts the attachment into a
+/// ByteArray with the format <key size><key payload><value size><value payload>, repeating this
+/// pattern for as many pairs there are in the attachment.
+///
+/// Both key size and value size are i32 integers with little endian format.
+///
+pub(crate) fn vec_to_attachment(bytes: Vec<u8>) -> Attachment {
+    let mut builder = AttachmentBuilder::new();
+    let mut idx = 0;
+    let i32_size = std::mem::size_of::<i32>();
+    let mut slice_size;
+
+    while idx < bytes.len() {
+        slice_size = i32::from_le_bytes(
+            bytes[idx..idx + i32_size]
+                .try_into()
+                .expect("Error decoding i32 while processing attachment."), //This error should never happen.
+        );
+        idx += i32_size;
+
+        let key = &bytes[idx..idx + slice_size as usize];
+        idx += slice_size as usize;
+
+        slice_size = i32::from_le_bytes(
+            bytes[idx..idx + i32_size]
+                .try_into()
+                .expect("Error decoding i32 while processing attachment."), //This error should never happen.
+        );
+        idx += i32_size;
+
+        let value = &bytes[idx..idx + slice_size as usize];
+        idx += slice_size as usize;
+
+        builder.insert(key, value);
+    }
+
+    builder.build()
 }


### PR DESCRIPTION
User attachment for Java Bindings.

The API is expanded with the following calls:

* `publisher.put(...).with_attachment(attachment)`
* `publisher.write(...).with_attachment(attachment)`
* `publisher.delete(...).with_attachment(attachment)`
* `session.put(...).with_attachment(attachment)`
* `query.reply(...).with_attachment(attachment)`
* `session.get(...).with_attachment(attachment)`

The Sample class now has an optional Attachment field as well.

Closes #29 