### PR TITLE
fix(ci): Update rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.74.0"


### PR DESCRIPTION
Upgrades rust toolchain from `1.72.0` to `1.74.0`, fixing the CI failure.