### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/src/main/java/io/zenoh/ZPub.java
+++ b/examples/src/main/java/io/zenoh/ZPub.java
@@ -25,12 +25,12 @@ public class ZPub {
             try (KeyExpr keyExpr = KeyExpr.tryFrom("demo/example/zenoh-java-pub")) {
                 System.out.println("Declaring publisher on '" + keyExpr + "'...");
                 try (Publisher publisher = session.declarePublisher(keyExpr).res()) {
-                    String payload = "Pub from Java!";
                     System.out.println("Press CTRL-C to quit...");
-                    int idx = 1;
+                    int idx = 0;
                     while (true) {
                         Thread.sleep(1000);
-                        System.out.println("Putting Data ('" + keyExpr + "': '[" + String.format("%4s", idx) + "] " + payload + "')...");
+                        String payload = String.format("[%4s] Pub from Java!", idx);
+                        System.out.println("Putting Data ('" + keyExpr + "': '"+payload+"')...");
                         publisher.put(payload).res();
                         idx++;
                     }

--- a/examples/src/main/java/io/zenoh/ZPub.java
+++ b/examples/src/main/java/io/zenoh/ZPub.java
@@ -26,7 +26,8 @@ public class ZPub {
                 System.out.println("Declaring publisher on '" + keyExpr + "'...");
                 try (Publisher publisher = session.declarePublisher(keyExpr).res()) {
                     String payload = "Pub from Java!";
-                    int idx = 0;
+                    System.out.println("Press CTRL-C to quit...");
+                    int idx = 1;
                     while (true) {
                         Thread.sleep(1000);
                         System.out.println("Putting Data ('" + keyExpr + "': '[" + String.format("%4s", idx) + "] " + payload + "')...");

--- a/examples/src/main/java/io/zenoh/ZPubThr.java
+++ b/examples/src/main/java/io/zenoh/ZPubThr.java
@@ -35,6 +35,7 @@ public class ZPubThr {
             try (KeyExpr keyExpr = KeyExpr.tryFrom("test/thr")) {
                 try (Publisher publisher = session.declarePublisher(keyExpr).congestionControl(CongestionControl.BLOCK).res()) {
                     System.out.println("Publisher declared on test/thr.");
+                    System.out.println("Press CTRL-C to quit...");
                     while (true) {
                         publisher.put(value).res();
                     }

--- a/examples/src/main/java/io/zenoh/ZQueryable.java
+++ b/examples/src/main/java/io/zenoh/ZQueryable.java
@@ -27,9 +27,10 @@ import java.util.concurrent.BlockingQueue;
 public class ZQueryable {
 
     public static void main(String[] args) throws ZenohException, InterruptedException {
+        String keyExprString = "demo/example/zenoh-java-queryable";
         try (Session session = Session.open()) {
-            try (KeyExpr keyExpr = KeyExpr.tryFrom("demo/example/zenoh-java-queryable")) {
-                System.out.println("Declaring Queryable");
+            try (KeyExpr keyExpr = KeyExpr.tryFrom(keyExprString)) {
+                System.out.println("Declaring Queryable on " + keyExprString + "...");
                 try (Queryable<BlockingQueue<Optional<Query>>> queryable = session.declareQueryable(keyExpr).res()) {
                     BlockingQueue<Optional<Query>> receiver = queryable.getReceiver();
                     assert receiver != null;

--- a/examples/src/main/java/io/zenoh/ZQueryable.java
+++ b/examples/src/main/java/io/zenoh/ZQueryable.java
@@ -33,6 +33,7 @@ public class ZQueryable {
                 try (Queryable<BlockingQueue<Optional<Query>>> queryable = session.declareQueryable(keyExpr).res()) {
                     BlockingQueue<Optional<Query>> receiver = queryable.getReceiver();
                     assert receiver != null;
+                    System.out.println("Press CTRL-C to quit...");
                     handleRequests(receiver, keyExpr);
                 }
             }

--- a/examples/src/main/java/io/zenoh/ZSub.java
+++ b/examples/src/main/java/io/zenoh/ZSub.java
@@ -32,6 +32,7 @@ public class ZSub {
                 try (Subscriber<BlockingQueue<Optional<Sample>>> subscriber = session.declareSubscriber(keyExpr).res()) {
                     BlockingQueue<Optional<Sample>> receiver = subscriber.getReceiver();
                     assert receiver != null;
+                    System.out.println("Press CTRL-C to quit...");
                     while (true) {
                         Optional<Sample> wrapper = receiver.take();
                         if (wrapper.isEmpty()) {

--- a/examples/src/main/java/io/zenoh/ZSubThr.java
+++ b/examples/src/main/java/io/zenoh/ZSubThr.java
@@ -23,12 +23,17 @@ public class ZSubThr {
 
     private static final long NANOS_TO_SEC = 1_000_000_000L;
     private static final long n = 50000L;
+    private static int batchCount = 0;
     private static int count = 0;
     private static long startTimestampNs = 0;
+    private static long globalStartTimestampNs = 0;
 
     public static void listener() {
         if (count == 0) {
             startTimestampNs = System.nanoTime();
+            if (globalStartTimestampNs == 0L) {
+                globalStartTimestampNs = startTimestampNs;
+            }
             count++;
             return;
         }
@@ -39,7 +44,17 @@ public class ZSubThr {
         long stop = System.nanoTime();
         double msgs = (double) (n * NANOS_TO_SEC) / (stop - startTimestampNs);
         System.out.println(msgs + " msgs/sec");
+        batchCount++;
         count = 0;
+    }
+
+    public static void report() {
+        long end = System.nanoTime();
+        long total = batchCount * n + count;
+        double msgs = (double) (end - globalStartTimestampNs) / NANOS_TO_SEC;
+        double avg = (double) (total * NANOS_TO_SEC) / (end - globalStartTimestampNs);
+        System.out.println("Received " + total + " messages in " + msgs +
+                ": averaged " + avg + " msgs/sec");
     }
 
     public static void main(String[] args) throws ZenohException, InterruptedException {
@@ -54,5 +69,6 @@ public class ZSubThr {
                 }
             }
         }
+        // report();
     }
 }

--- a/examples/src/main/java/io/zenoh/ZSubThr.java
+++ b/examples/src/main/java/io/zenoh/ZSubThr.java
@@ -19,8 +19,6 @@ import io.zenoh.keyexpr.KeyExpr;
 import io.zenoh.subscriber.Subscriber;
 import kotlin.Unit;
 
-import java.util.Scanner;
-
 public class ZSubThr {
 
     private static final long NANOS_TO_SEC = 1_000_000_000L;
@@ -59,19 +57,18 @@ public class ZSubThr {
                 ": averaged " + avg + " msgs/sec");
     }
 
-    public static void main(String[] args) throws ZenohException {
+    public static void main(String[] args) throws ZenohException, InterruptedException {
         System.out.println("Opening Session");
         try (Session session = Session.open()) {
             try (KeyExpr keyExpr = KeyExpr.tryFrom("test/thr")) {
                 try (Subscriber<Unit> subscriber = session.declareSubscriber(keyExpr).with(sample -> listener()).res()) {
-                    Scanner scanner = new Scanner(System.in);
-                    while (!scanner.nextLine().equals("q")) {
-                        // Do nothing
+                    System.out.println("Press CTRL-C to quit...");
+                    while (true) {
+                        Thread.sleep(1000);
                     }
-                    scanner.close();
                 }
             }
         }
-        report();
+        // report();
     }
 }

--- a/examples/src/main/java/io/zenoh/ZSubThr.java
+++ b/examples/src/main/java/io/zenoh/ZSubThr.java
@@ -48,6 +48,7 @@ public class ZSubThr {
         count = 0;
     }
 
+    // TODO: perform report at end of measurement
     public static void report() {
         long end = System.nanoTime();
         long total = batchCount * n + count;
@@ -69,6 +70,5 @@ public class ZSubThr {
                 }
             }
         }
-        // report();
     }
 }

--- a/examples/src/main/java/io/zenoh/ZSubThr.java
+++ b/examples/src/main/java/io/zenoh/ZSubThr.java
@@ -23,17 +23,12 @@ public class ZSubThr {
 
     private static final long NANOS_TO_SEC = 1_000_000_000L;
     private static final long n = 50000L;
-    private static int batchCount = 0;
     private static int count = 0;
     private static long startTimestampNs = 0;
-    private static long globalStartTimestampNs = 0;
 
     public static void listener() {
         if (count == 0) {
             startTimestampNs = System.nanoTime();
-            if (globalStartTimestampNs == 0L) {
-                globalStartTimestampNs = startTimestampNs;
-            }
             count++;
             return;
         }
@@ -44,17 +39,7 @@ public class ZSubThr {
         long stop = System.nanoTime();
         double msgs = (double) (n * NANOS_TO_SEC) / (stop - startTimestampNs);
         System.out.println(msgs + " msgs/sec");
-        batchCount++;
         count = 0;
-    }
-
-    public static void report() {
-        long end = System.nanoTime();
-        long total = batchCount * n + count;
-        double msgs = (double) (end - globalStartTimestampNs) / NANOS_TO_SEC;
-        double avg = (double) (total * NANOS_TO_SEC) / (end - globalStartTimestampNs);
-        System.out.println("Received " + total + " messages in " + msgs +
-                ": averaged " + avg + " msgs/sec");
     }
 
     public static void main(String[] args) throws ZenohException, InterruptedException {
@@ -69,6 +54,5 @@ public class ZSubThr {
                 }
             }
         }
-        // report();
     }
 }


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects.

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.

Related PRs:
- https://github.com/eclipse-zenoh/zenoh/pull/768
- https://github.com/eclipse-zenoh/zenoh-c/pull/255
- https://github.com/eclipse-zenoh/zenoh-cpp/pull/103
- https://github.com/eclipse-zenoh/zenoh-kotlin/pull/47
- https://github.com/eclipse-zenoh/zenoh-pico/pull/359
- https://github.com/eclipse-zenoh/zenoh-python/pull/150