### PR TITLE
fix: Use macos-13 instead of macos-14 runners in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CI workflow was failing because macos-latest now refers to macos-14 and the nttld/setup-ndk action doesn't support AArch64.
