### PR TITLE
Update rustc version and how cross is installed via cargo

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -78,7 +78,7 @@ jobs:
               ;;
           esac
 
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo +stable install cross --locked
 
       - name: Install Rust toolchain
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.72.0"


### PR DESCRIPTION
Similar to https://github.com/eclipse-zenoh/zenoh-kotlin/pull/86, this fixes how cargo installs cross and pins rustc to 1.72.0