### PR TITLE
fix: cargo-deb install from +stable and --locked

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            *-linux-gnu*) cargo install cargo-deb ;;
+            *-linux-gnu*) cargo +stable install cargo-deb --locked;;
           esac
 
           case ${{ matrix.job.target }} in


### PR DESCRIPTION
Attempt to fix https://github.com/eclipse-zenoh/zenoh-kotlin/issues/99