### PR TITLE
Add Query `Consolidation::Auto` to JNI and Java API

### DIFF
--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/query/ConsolidationMode.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/query/ConsolidationMode.kt
@@ -16,6 +16,9 @@ package io.zenoh.query
 
 /** The kind of consolidation. */
 enum class ConsolidationMode {
+    /** Apply automatic consolidation based on queryable's preferences. */
+    AUTO,
+
     /** No consolidation applied: multiple samples may be received for the same key-timestamp.*/
     NONE,
 

--- a/zenoh-jni/src/utils.rs
+++ b/zenoh-jni/src/utils.rs
@@ -107,9 +107,10 @@ pub(crate) fn decode_query_target(target: jint) -> Result<QueryTarget> {
 
 pub(crate) fn decode_consolidation(consolidation: jint) -> Result<ConsolidationMode> {
     match consolidation {
-        0 => Ok(ConsolidationMode::None),
-        1 => Ok(ConsolidationMode::Monotonic),
-        2 => Ok(ConsolidationMode::Latest),
+        0 => Ok(ConsolidationMode::Auto),
+        1 => Ok(ConsolidationMode::None),
+        2 => Ok(ConsolidationMode::Monotonic),
+        3 => Ok(ConsolidationMode::Latest),
         value => Err(session_error!("Unable to decode consolidation '{}'", value)),
     }
 }


### PR DESCRIPTION
Mainly motivated by the need to align default behavior of `get` with implementations in other bindings.

Sister PR:
- [ ] https://github.com/eclipse-zenoh/zenoh-kotlin/pull/158