### PR TITLE
resolve the issue of java.lang.NullPointerException in springboot jar

### DIFF
--- a/zenoh-java/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-java/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
@@ -108,7 +108,7 @@ internal actual class Zenoh private actual constructor() {
         }
 
         private fun loadLibraryAsInputStream(target: Target): Result<InputStream> = runCatching {
-            val libUrl = ClassLoader.getSystemClassLoader().getResourceAsStream("$target/$target.zip")!!
+            val libUrl = javaClass.getResourceAsStream("/$target/$target.zip")!!
             val uncompressedLibFile = unzipLibrary(libUrl)
             return Result.success(FileInputStream(uncompressedLibFile.getOrThrow()))
         }


### PR DESCRIPTION
When using zenoh java jvm in springboot jar, the following error occurred：

java.lang.Exception: Unable to load Zenoh JNI: java.lang.NullPointerException
        at io.zenoh.Zenoh$Companion.tryLoadingLibraryFromJarPackage-IoAF18A(Zenoh.kt:137)
        at io.zenoh.Zenoh$Companion.access$tryLoadingLibraryFromJarPackage-IoAF18A(Zenoh.kt:29)
        at io.zenoh.Zenoh.<init>(Zenoh.kt:161)
        at io.zenoh.Zenoh.<init>(Zenoh.kt)
        at io.zenoh.Zenoh$Companion.load(Zenoh.kt:36)
        at io.zenoh.Session.<init>(Session.kt:90)
        at io.zenoh.Session.<init>(Session.kt)
        at io.zenoh.Session$Companion.open(Session.kt:70)
        at io.zenoh.Session.open(Session.kt)
        at com.kernelsoft.zenoh.handler.ZenohSubHandler.subKey(ZenohSubHandler.java:64)
        at com.kernelsoft.zenoh.handler.ZenohSubHandler.lambda$startZenohSub$0(ZenohSubHandler.java:48)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)