### PR TITLE
Disabling java tests when Android is enabled

### DIFF
--- a/zenoh-java/build.gradle.kts
+++ b/zenoh-java/build.gradle.kts
@@ -50,7 +50,11 @@ kotlin {
             val zenohPaths = "../zenoh-jni/target/$buildMode"
             jvmArgs("-Djava.library.path=$zenohPaths")
         }
-        withJava()
+        if (!androidEnabled) {
+            withJava() // Adding java to a kotlin lib targeting android is incompatible
+                       // The java code is only meant for testing and is non-critical for the android publication.
+                       // Therefore, when enabling android we disable the java code.
+        }
     }
     if (androidEnabled) {
         androidTarget {


### PR DESCRIPTION
This PR solves the issue of the CI workflows failing when attempting to build an Android package.

The reason for it failing is that it's not possible to target android while having mixed kotlin and java code.

However, the only java code we use is on the tests to validate the API. Since there are no android specific tests, we can safely disable the `withJava()` config when enabling android, solving the build problem.