### PR TITLE
fix: update release workflow for scheduled event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
       branch: ${{ needs.tag.outputs.branch }}
-      maven_publish: ${{ inputs.maven_publish }}
+      maven_publish: ${{ !contains(inputs.maven_publish, 'false') }}
     permissions:
       contents: read
       packages: write
@@ -93,7 +93,7 @@ jobs:
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
       branch: ${{ needs.tag.outputs.branch }}
-      maven_publish: ${{ inputs.maven_publish }}
+      maven_publish: ${{ !contains(inputs.maven_publish, 'false') }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
During scheduled events, inputs are null, so we need to set this logic with contains() so we can:
- default to maven_publish=true, when workflow_dispatch is called
- allow maven_publish=true, when workflow_dispatch is called
- default to maven_publish=true, when running on a schedule

Should fix https://github.com/eclipse-zenoh/zenoh-java/actions/runs/13125305726