### PR TITLE
chore: update ubuntu runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -34,13 +34,13 @@ jobs:
           - {
             target: x86_64-unknown-linux-gnu,
             arch: amd64,
-            os: ubuntu-20.04,
+            os: ubuntu-24.04,
             build-cmd: "cargo",
           }
           - {
             target: aarch64-unknown-linux-gnu,
             arch: arm64,
-            os: ubuntu-20.04,
+            os: ubuntu-24.04,
             build-cmd: "cross",
           }
           - {


### PR DESCRIPTION
ubuntu-20.04 runners are being deprecated.