### PR TITLE
ci: update sonatype.org url to use new domain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,8 +47,8 @@ version = if (project.hasProperty("SNAPSHOT")) {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl = uri("https://oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            nexusUrl = uri("https://central.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.org/content/repositories/snapshots/")
 
             username = System.getenv("ORG_OSSRH_USERNAME")
             password = System.getenv("ORG_OSSRH_PASSWORD")


### PR DESCRIPTION
As per https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6270#note_4175210 we should use central.sonatype.org instead of oss.s.o