### PR TITLE
chore: setup gradle for docs publication

### DIFF
--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: 8.12.1
+
+      - name: Gradle Wrapper
+        run: |
+          gradle wrapper
+
       - name: Build doc
         run: gradle dokkaGenerate
 


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh-java/actions/runs/16867845041/job/47801963320