### PR TITLE
Received preset encodings are value-only end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: af690927669551791fda895e5af98ef7bc1220d6
+          ref: 1e040c96d0729c387d411a2356f361e9ea420877
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: e8023170c0be3d8e5cd2cee17487870b27af6728
+          ref: af690927669551791fda895e5af98ef7bc1220d6
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/FlatCallbacks.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/FlatCallbacks.kt
@@ -66,7 +66,7 @@ internal fun replyCallbackOf(
             if (isOk) {
                 Reply.Success(
                     replierId,
-                    Sample.fromParts(keH!!, payloadH!!, encId!!, encSchema, encH!!, kindInt!!, ntp64, express!!, prioInt!!, ccInt!!, attachH, reliabilityInt!!, sourceZid, sourceEid!!, sourceSn!!)
+                    Sample.fromParts(keH!!, payloadH!!, encId!!, encSchema, encH, kindInt!!, ntp64, express!!, prioInt!!, ccInt!!, attachH, reliabilityInt!!, sourceZid, sourceEid!!, sourceSn!!)
                 )
             } else {
                 Reply.Error(

--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Sample.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/sample/Sample.kt
@@ -59,7 +59,9 @@ data class Sample(
          * callbacks), in record order. The whole graph arrives in ONE JNI
          * crossing; the [KeyExpr] retains the delivered handle leaf, and the
          * [Encoding] retains its delivered handle (`encH`) so re-sending it
-         * crosses a bare `jlong` instead of rebuilding the native value. The
+         * crosses a bare `jlong` instead of rebuilding the native value —
+         * delivered ONLY for schema-carrying encodings (a preset re-sends
+         * through the id arm for free, so it arrives value-only). The
          * trailing `reliability` / `source*` leaves are part of the generated
          * decomposition but are not surfaced on the public [Sample] type.
          */
@@ -69,7 +71,7 @@ data class Sample(
             payloadH: io.zenoh.jni.bytes.ZBytes,
             encId: Int,
             encSchema: String?,
-            encH: io.zenoh.jni.bytes.Encoding,
+            encH: io.zenoh.jni.bytes.Encoding?,
             kindInt: Int,
             ntp64: Long?,
             express: Boolean,

--- a/zenoh-java/src/jvmTest/kotlin/io/zenoh/EncodingHandleTest.kt
+++ b/zenoh-java/src/jvmTest/kotlin/io/zenoh/EncodingHandleTest.kt
@@ -33,9 +33,11 @@ import org.junit.Test
  *   the send call itself, no handle ever exists;
  * - custom (schema-carrying) encodings own a handle from construction —
  *   construction is the one crossing, every send after is a bare jlong;
- * - received encodings arrive WITH their handle in the same delivery
- *   crossing, so re-sending one (the save-and-republish scenario) never
- *   rebuilds the native value from its schema string.
+ * - received SCHEMA-CARRYING encodings arrive WITH their handle in the same
+ *   delivery crossing, so re-sending one (the save-and-republish scenario)
+ *   never rebuilds the native value from its schema string; a received
+ *   PRESET arrives value-only — its handle would buy nothing (the id arm is
+ *   free), so the binding never materializes one (`encoding_if_schema`).
  */
 class EncodingHandleTest {
 
@@ -95,7 +97,7 @@ class EncodingHandleTest {
     }
 
     @Test
-    fun predefinedRoundTripStaysValueOnSendAndHandleOnReceive() {
+    fun predefinedRoundTripStaysValueOnlyEndToEnd() {
         val session = Zenoh.open(Config.loadDefault())
         val keyExpr = KeyExpr.tryFrom("example/testing/encoding/preset")
         val received = mutableListOf<Sample>()
@@ -110,8 +112,10 @@ class EncodingHandleTest {
         assertNull(Encoding.TEXT_PLAIN.handle)
         assertEquals(1, received.size)
         assertEquals(Encoding.TEXT_PLAIN, received[0].encoding)
-        // …while the received copy arrived send-ready.
-        assertNotNull(received[0].encoding.handle)
+        // …and the received copy is value-only too: a schema-less encoding
+        // re-sends through the id arm for free, so no per-message native
+        // handle (clone + Box + wrapper + Cleaner) is ever materialized.
+        assertNull(received[0].encoding.handle)
 
         subscriber.close()
         session.close()


### PR DESCRIPTION
## What

Consumes ZettaScaleLabs/zenoh-flat-jni#6 (merged as `1e040c9`): the encoding handle delivered with a received sample/query/reply is **conditional on schema presence**. A received preset (schema-less) encoding arrives value-only — it re-sends through the `(id, schema)` value arm for free, so the per-message native handle it used to carry (Rust clone+Box, JVM wrapper + atomic cell + gc-Cleaner registration, later Cleaner free — the +150 ns class measured in milyin/prebindgen#83) is never materialized. Schema-carrying (custom) encodings keep the send-ready handle from #485.

The condition lives in the **binding tier** (`encoding_if_schema` in zenoh-flat-jni, declared with prebindgen's binding-local `fun!(crate::…).sig(sig!(…))` vocabulary from milyin/prebindgen#84) — zenoh-flat stays pure.

## Changes

- `Sample.fromParts` `encH` becomes nullable (`Query.fromParts` already was); the reply callback drops its non-null assertion on the ok-arm handle leaf.
- `EncodingHandleTest`: the preset round-trip flips to `assertNull(received.encoding.handle)` — the new contract, asserted end to end; the custom-encoding round-trip still verifies a delivered handle + same-handle re-send.
- CI pin bumped to the zenoh-flat-jni#6 **merge commit** (`1e040c9`).

**110 jvmTest, 0 failures** against merged flat-jni main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)