### PR TITLE
fix(ZBytes): publish the lazy byte cache safely

### DIFF
--- a/zenoh-java/src/commonMain/kotlin/io/zenoh/bytes/ZBytes.kt
+++ b/zenoh-java/src/commonMain/kotlin/io/zenoh/bytes/ZBytes.kt
@@ -48,9 +48,18 @@ import io.zenoh.jni.bytes.ZBytes as JniZBytes
  * dropped samples are the one place native memory can be retained.
  */
 class ZBytes private constructor(
-    private var eager: ByteArray?,
+    initialBytes: ByteArray?,
     private var handle: JniZBytes?,
 ) : IntoZBytes {
+
+    /**
+     * The materialized bytes, `null` until a handle-backed ZBytes is read.
+     * Volatile: the [bytes] getter reads it outside the monitor, so the write
+     * under the monitor must be safely published to that unlocked fast path.
+     * `handle` needs no such treatment — it is only touched inside the monitor.
+     */
+    @Volatile
+    private var eager: ByteArray? = initialBytes
 
     internal constructor(bytes: ByteArray) : this(bytes, null)
 


### PR DESCRIPTION
Fixes the unsafe double-checked locking in `io.zenoh.bytes.ZBytes` reported in #516.

The lazy materialization reads `eager` on the unsynchronized fast path and writes it under `synchronized(this)`. Without `@Volatile`, a thread that observes the non-null `ByteArray` reference has no happens-before edge to the copy that filled it, so it can read stale or partial contents once a `Sample`/`ZBytes` escapes to more than one thread.

`eager` is now `@Volatile`. It moves out of the primary constructor because `@Volatile` targets fields. The `synchronized` slow path is unchanged — it is what guarantees exactly one thread copies out of and closes the native handle. `handle` stays non-volatile: it is only read and written inside the monitor.

Mirrors eclipse-zenoh/zenoh-kotlin#696. `git grep synchronized -- zenoh-java/src` confirms this was the only DCL site in the SDK.

Out of scope, per the issue: mutability of the returned `ByteArray`, and the native-memory leak when a received payload is never materialized.

Verified with `./gradlew :zenoh-java:compileKotlinJvm -PuseLocalFlatJni=true`. No new test — a memory-visibility fix has no deterministic JVM test, and the materialization semantics the existing `ZBytesTests` cover are unchanged.

Closes #516