### PR TITLE
CI: resolve zenoh-flat-jni in the build, and stop rebuilding it here

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           repository: eclipse-zenoh/zenoh-flat-jni
           # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
           # from git, so its Cargo.lock is the pin that decides.
-          ref: 80f0d09abac4d4201842d06ad0c0791876472fae
+          ref: e75529ce3758401ce213456e7b8e4e5667635cf8
           path: zenoh-flat-jni
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,35 +41,30 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      # zenoh-flat-jni pins its toolchain in rust-toolchain.toml. Install it
+      # from that directory, so a missing toolchain fails here rather than
+      # inside the Gradle build - and so this repo never has to name a version
+      # its dependency is free to change.
+      #
+      # Nothing else Rust runs here. Formatting, clippy, the feature-leak test
+      # and the native build are zenoh-flat-jni's own CI, on three platforms,
+      # for the very commit pinned above; re-running them from this repo only
+      # adds ways for the two toolchains to disagree.
       - name: Install Rust toolchain
-        run: |
-          rustup show
-          rustup component add rustfmt clippy --toolchain 1.93.0
-
-      - name: Cargo Format
         working-directory: zenoh-flat-jni
-        run: cargo fmt --check
-
-      - name: Clippy Check
-        working-directory: zenoh-flat-jni
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Check for feature leaks
-        working-directory: zenoh-flat-jni
-        run: cargo test --no-default-features
-
-      - name: Build zenoh-flat-jni
-        working-directory: zenoh-flat-jni
-        run: cargo build
+        run: rustup show
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: Gradle Test
         working-directory: zenoh-java
-        # CI builds against the sibling checkouts above, so it opts into the
+        # CI builds against the sibling checkout above, so it opts into the
         # composite build explicitly. A release does not: it resolves
         # zenoh-flat-jni from Maven Central like any other consumer.
+        #
+        # No cargo step precedes this: the composite build's test task depends
+        # on zenoh-flat-jni's own native build, so Gradle drives cargo.
         run: ./gradlew jvmTest --info -PuseLocalFlatJni=true
 
   markdown_lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
-          # from git, so its Cargo.lock is the pin that decides.
-          ref: e75529ce3758401ce213456e7b8e4e5667635cf8
+          # No ref: track that repository's default branch. A pinned commit has
+          # to be hand-edited for every upstream fix, and this is the one hop
+          # in the chain no bot covers - zenoh-flat-jni's own Cargo.lock is
+          # kept aligned with zenoh for it, so following its main keeps the
+          # whole chain automatic. zenoh-flat is not checked out at all: it is
+          # resolved from git by that lockfile.
           path: zenoh-flat-jni
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          ref: 6f81eb8f9d5c49b72dda2fb054a174cce3184f2a
+          # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
+          # from git, so its Cargo.lock is the pin that decides.
+          ref: 80f0d09abac4d4201842d06ad0c0791876472fae
           path: zenoh-flat-jni
-
-      - name: Check out zenoh-flat
-        uses: actions/checkout@v4
-        with:
-          repository: eclipse-zenoh/zenoh-flat
-          ref: 81feb940cce9f4c3b33a87de397b2ce42cb5fc9e
-          path: zenoh-flat
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Fixes a latent ~1/256 flake in `QueryableTest`, and takes this repository out of
the business of pinning, building and linting its Rust dependency. The mechanism
matches eclipse-zenoh/zenoh-kotlin#700 exactly, so the two SDKs stay one thing.

## The flake

zenoh-flat carried a timestamp's node id trimmed to its significant bytes, while
`ZenohId` carries the full zero-padded width — the same node as two different
byte strings whenever its identifier has a high-order zero byte, i.e. about once
in 256 sessions, with both sides *rendering* identically.

`QueryableTest.queryableRunsWithCallback` asserts exactly that equality
(`assertEquals(timestamp, receivedSample.getTimestamp())` against a timestamp
stamped with `session.info().zid()`). It was caught downstream in
eclipse-zenoh/zenoh-kotlin#669, where the same assertion failed on one runner
and passed on the other for the same commit.

Fixed upstream in eclipse-zenoh/zenoh-flat#86, picked up by
eclipse-zenoh/zenoh-flat-jni#35.

## Where the pin lives now

It was a SHA hand-edited in `ci.yml` — which is how the fix above sat upstream
while CI kept testing the commit the pin named. It is now a resolved lockfile
entry, because a lockfile is the one pin `eclipse-zenoh/ci` already moves for
every zenoh dependant.

A crate at the repository root — `Cargo.toml`, `ci/pin.rs`, `rust-toolchain.toml`
— compiles to nothing anyone ships. Its whole content is one dependency:

```toml
zenoh-flat-jni = { git = "…/zenoh-flat-jni.git", branch = "main" }
```

```text
Cargo.lock:  source = "git+…/zenoh-flat-jni.git?branch=main#<40-hex commit>"
```

The lockfile sync overwrites `Cargo.lock` with zenoh's — which carries no
`zenoh-flat-jni` entry, so the pin is removed — resolves again, which writes back
the current commit, and compiles the result before opening its auto-merging pull
request. At the **root**, so this repository stops being one of that workflow's
two crate-path special cases; eclipse-zenoh/ci#466 deletes the case once both
SDKs are here.

## Where the source comes from

`settings.gradle.kts` decides, in one place:

| | says "use this source" | where it comes from |
| --- | --- | --- |
| 1 | `-PflatJniDir=<path>` | that directory, as it is |
| 2 | `path = "…"` in `Cargo.toml` | that directory, as it is |
| 3 | `-PuseLocalFlatJni=true` | the commit `Cargo.lock` pins, fetched into `.zenoh-flat-jni/` |
| 4 | nothing | Maven Central — no composite build |

Row 2 is the point: working against your own checkout is the ordinary Cargo edit,
and `./gradlew build` follows it with no properties at all. Gradle only *reads*
the two Cargo files — it never runs Cargo against them — so that edit leaves
`Cargo.lock` alone.

Row 3 is the whole of what CI does, so `./gradlew jvmTest -PuseLocalFlatJni=true`
reproduces a CI run anywhere. Row 4 is what a release takes, and
`build.gradle.kts` now refuses to publish while zenoh-flat-jni is an included
build — a leftover from rows 1–3 would otherwise publish an artifact built from a
working copy under a POM naming a release.

## The rest of the Rust part

Bumping the pin first surfaced the other half: `cargo fmt --check` failed with
`'cargo-fmt' is not installed for the toolchain '1.97.1'`. The workflow added
rustfmt and clippy to a hardcoded `1.93.0`, while the checks ran under the
toolchain zenoh-flat-jni pins.

Rather than chase the version, the checks go: `cargo fmt --check`, clippy,
`cargo test --no-default-features` and `cargo build` are zenoh-flat-jni's own CI,
on three platforms. Its format check also passes an import-granularity config
this bare `cargo fmt` never applied, so the two were not even the same check.
`cargo build` was redundant besides — the composite build's test task depends on
zenoh-flat-jni's native build, so Gradle drives cargo.

The dead `Check out zenoh-flat` step is gone too: nothing ever read it, and
zenoh-flat is resolved from git by zenoh-flat-jni's own lockfile.

What remains of Rust here is `rust-toolchain.toml` — tracking zenoh-flat-jni's
channel, because that is what has to compile — and `rustup show`. The workflow is
five steps and names no commit.

## Verification

All four rows exercised locally; `jvmTest` passes through the composite (112
tests). zenoh-flat-jni#35 is green on all three platforms, including the format,
clippy and generated-artifact checks dropped here, and zenoh-kotlin#700 — the
same mechanism — is green on both of its.