### PR TITLE
PUBLISHING.md: how to rehearse a release while zenoh-flat-jni is unreleased

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,6 +22,7 @@ which covers them once for both repositories.
   - [The real release](#the-real-release)
   - [After a release](#after-a-release)
 - [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released)
+  - [Rehearsing the release workflow with a snapshot](#rehearsing-the-release-workflow-with-a-snapshot)
 - [How the pipeline works](#how-the-pipeline-works)
 - [Building against zenoh-flat-jni source](#building-against-zenoh-flat-jni-source)
 - [Required secrets](#required-secrets)
@@ -117,7 +118,7 @@ builds and publishes.
 | --- | --- |
 | `live-run` | **unchecked** |
 | `version` | a fresh provisional number, not one already used |
-| `zenoh-flat-jni-version` | leave empty for a rehearsal, or a released version |
+| `zenoh-flat-jni-version` | a version that exists — today a snapshot, see [below](#rehearsing-the-release-workflow-with-a-snapshot). Empty falls back to `gradle.properties`, which names an unreleased version and fails |
 | `maven_publish` | checked — or uncheck for the very first run |
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
@@ -173,11 +174,42 @@ published — a rehearsal there with `maven_publish` enabled uploads
 Nothing needs editing. Name the version on the command line:
 
 ```bash
-./gradlew build -PzenohFlatJniVersion=1.9.0-rc4-SNAPSHOT
+./gradlew build -PzenohFlatJniVersion=1.9.0-rc8-SNAPSHOT
 ```
 
-or pass the same value as the `zenoh-flat-jni-version` input to a rehearsal of
-the release workflow.
+### Rehearsing the release workflow with a snapshot
+
+Find what is actually published — the list moves as zenoh-flat-jni rehearses:
+
+```bash
+curl -s https://central.sonatype.com/repository/maven-snapshots/org/eclipse/zenoh/zenoh-flat-jni/maven-metadata.xml
+```
+
+```xml
+<latest>1.9.0-rc8-SNAPSHOT</latest>
+```
+
+Then run **Release** from the Actions tab with:
+
+| input | value |
+| --- | --- |
+| `live-run` | **unchecked** — a live run refuses a `-SNAPSHOT` binding |
+| `zenoh-flat-jni-version` | the version above, e.g. `1.9.0-rc8-SNAPSHOT` |
+| `maven_publish` | checked to rehearse the upload too, unchecked to stop at assembly |
+| `version`, `branch` | leave empty unless you are rehearsing a specific one |
+
+**`zenoh-flat-jni-version` is the field that matters.** Left empty, the build
+falls back to `zenohFlatJniVersion` in `gradle.properties` — currently `1.9.0`,
+which is not on Maven Central, and the run dies while compiling:
+
+```text
+Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
+```
+
+That is the conditional repository below doing its job, not a broken build: a
+non-snapshot version never gets the snapshot repository on its resolution path.
+The same applies to the nightly scheduled run of `release.yml`, which passes no
+inputs and so fails this way until zenoh-flat-jni is released for real.
 
 The Central snapshot repository is declared **conditionally** in
 `build.gradle.kts`, and this is the part worth understanding:


### PR DESCRIPTION
Documentation only, following up on the pin work that just merged.

A dispatched **Release** rehearsal fails in the publish job before anything is
uploaded. Observed in zenoh-kotlin ([run 31442164522](https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/31442164522/job/93629004811)):

```text
Execution failed for task ':zenoh-kotlin:compileKotlinJvm'.
> Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
```

This repository has not been rehearsed since, but it fails identically by
construction: same `release.yml` inputs and nightly cron, same
`zenohFlatJniVersion=1.9.0` in `gradle.properties`, same conditional snapshot
repository.

Not a broken build. `org.eclipse.zenoh:zenoh-flat-jni` is not on Maven Central at
all yet — its `maven-metadata.xml` there 404s. What exists is in the Central
*snapshot* repository:

```xml
<latest>1.9.0-rc8-SNAPSHOT</latest>   <!-- plus 1.9.0-rc4-SNAPSHOT -->
```

and `build.gradle.kts` adds that repository only when `zenohFlatJniVersion` ends
in `-SNAPSHOT`, so that a release can never resolve a mutable artifact. Ask for
`1.9.0` and the snapshot repository is deliberately not on the resolution path.

The run asked for `1.9.0` because `zenoh-flat-jni-version` was left empty and the
build fell back to `gradle.properties`. **PUBLISHING.md was telling people to do
that** — the dry-run table read "leave empty for a rehearsal". So this fixes the
instruction and documents the working procedure:

- how to find what is actually published, since the snapshot list moves as
  zenoh-flat-jni rehearses (the doc had `rc4` hardcoded, and `rc8` is current);
- the inputs for a rehearsal — `live-run` unchecked, because a live run refuses a
  `-SNAPSHOT` binding, and `zenoh-flat-jni-version` set to a version that exists;
- why the failure reads the way it does, so the next person recognises it as the
  conditional repository doing its job.

It also notes that `release.yml`'s nightly `cron: "0 0 * * 1-5"` passes no inputs
and so fails this way every weeknight until zenoh-flat-jni is released for real.

**Not fixed here:** that nightly red run. Silencing it is a workflow change —
drop the `schedule:` block, or have the scheduled path name a snapshot — and it
seemed better kept separate from a documentation fix. Happy to open it.

The same change is in eclipse-zenoh/zenoh-kotlin#701, where the failure was observed.
