### PR TITLE
CI: pin third-party actions, fix the triggers, drop both nightlies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Third-party actions are pinned to a commit, with the version in a trailing
+# comment: a tag is mutable, and a moved tag runs code nobody reviewed. Actions
+# under eclipse-zenoh/ are ours and stay on a branch.
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -23,11 +26,11 @@ jobs:
 
     steps:
       - name: Check out zenoh-java
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: zenoh-java
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 11
@@ -44,8 +47,10 @@ jobs:
         working-directory: zenoh-java
         run: rustup show
 
+      # v5, not v6: v6 moved caching into a proprietary component under Gradle's
+      # own terms of use, which is not ours to accept for an Eclipse project.
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Gradle Test
         working-directory: zenoh-java
@@ -63,8 +68,11 @@ jobs:
   markdown_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v18
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Pinned where it stands. v18 runs on node20, which is not retired, and a
+      # newer major changes markdownlint's rules - an upgrade to make on its own,
+      # not inside a pinning change.
+      - uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0 # v18
         with:
           config: '.markdownlint.yaml'
           globs: '**/README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,26 @@
 name: CI
 
 on:
+  # `release/*` because that is where a release is actually built from: the
+  # release workflow creates the branch through the shared
+  # eclipse-zenoh/ci/create-release-branch action, and without this CI never runs
+  # on it. The dry-run branches that same action produces are excluded - they are
+  # throwaway.
   push:
-    branches: ["**"]
+    branches: ["main", "release/*", "!release/dry-run/*"]
+  # Every branch, not just main: a backport pull request targets a release
+  # branch, and it needs CI as much as any other. Not `push` on every branch as
+  # well - with this on, that runs the whole matrix twice per branch.
   pull_request:
     branches: ["**"]
-  schedule:
-    - cron: "0 6 * * 1-5"
+  # No schedule. The obvious argument for a nightly is that it would catch
+  # zenoh-flat-jni moving under us, and it would not: Cargo.lock pins that
+  # dependency to a commit, and Cargo re-resolves a git dependency only on
+  # `cargo update`, so a timed build rebuilds exactly what the last merge built.
+  # Upstream drift arrives here as a lockfile-sync pull request, which runs CI
+  # like anything else. What is left is an expired Central token or GPG key,
+  # caught only in a week with no merges at all - a thin canary against a daily
+  # publication. workflow_dispatch runs the path on demand.
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -16,24 +16,29 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Third-party actions are pinned to a commit, with the version in a trailing
+# comment: a tag is mutable, and a moved tag runs code nobody reviewed.
 jobs:
   build_doc_and_deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 
+      # v5, not v6: v6 moved caching into a proprietary component under Gradle's
+      # own terms of use, which is not ours to accept for an Eclipse project.
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Build doc
         run: ./gradlew dokkaGenerate
 
+      # v4, not the v3 this was on: v3 runs on node16, a retired Actions runtime.
       - name: Deploy doc
         if: ${{ inputs.live-run || false }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./zenoh-java/build/dokka/javadoc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,10 @@ on:
 # org.eclipse.zenoh:zenoh-flat-jni artifact this SDK depends on, already
 # cross-compiled and verified by that repository's release. This workflow only
 # compiles Kotlin and publishes.
+#
+# Third-party actions are pinned to a commit, with the version in a trailing
+# comment: a tag is mutable, and a moved tag runs code nobody reviewed. Actions
+# under eclipse-zenoh/ are ours and stay on a branch.
 jobs:
   publish_package:
     name: Publish to Maven Central
@@ -36,17 +40,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 11
 
+      # v5, not v6: v6 moved caching into a proprietary component under Gradle's
+      # own terms of use, which is not ours to accept for an Eclipse project.
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       # Assembles the artifact and generates its POM without uploading, so a
       # `maven_publish: false` rehearsal actually proves something. Only the
@@ -82,7 +88,7 @@ jobs:
 
       - name: "Upload gradle problems report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: problem-reports-${{ github.job }}.zip
           path: ${{ github.workspace }}/build/reports/problems/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,12 @@ jobs:
           branch: ${{ inputs.branch }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
+      # Third-party actions are pinned to a commit, with the version in a
+      # trailing comment: a tag is mutable, and a moved tag runs code nobody
+      # reviewed. The eclipse-zenoh/ci actions above and below are ours, and stay
+      # on a branch.
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.create-release-branch.outputs.branch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,11 @@
 name: Release
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
+  # Dispatch only. The weekday schedule this had ran a dry-run release every
+  # night with no inputs, which means no `zenoh-flat-jni-version` - so it
+  # resolved the unreleased fallback in gradle.properties and died compiling,
+  # every night. A release is a deliberate act, and rehearsing one is a
+  # deliberate act too; both are `Run workflow` here. See PUBLISHING.md.
   workflow_dispatch:
     inputs:
       live-run:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -208,8 +208,11 @@ Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
 
 That is the conditional repository below doing its job, not a broken build: a
 non-snapshot version never gets the snapshot repository on its resolution path.
-The same applies to the nightly scheduled run of `release.yml`, which passes no
-inputs and so fails this way until zenoh-flat-jni is released for real.
+
+`release.yml` used to run on a weekday schedule as well, and a scheduled run
+passes no inputs — so it failed exactly this way every night. The schedule is
+gone: the workflow is `workflow_dispatch` only, and a rehearsal is something you
+start on purpose, with the version filled in.
 
 The Central snapshot repository is declared **conditionally** in
 `build.gradle.kts`, and this is the part worth understanding:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -258,6 +258,13 @@ in the README.
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.
 
+Every third-party action these workflows use is pinned to a **commit SHA**, with
+the version in a trailing comment — a tag is mutable, and a moved tag would run
+code nobody reviewed on a job that holds the signing key and the Central token.
+The `eclipse-zenoh/ci` actions are ours and stay on `@main` deliberately: the
+tagging and GitHub-release steps track whatever that branch holds at run time.
+Bumping a pin is an ordinary pull request; read the diff of the action first.
+
 ## Building against zenoh-flat-jni source
 
 A build can be pointed at zenoh-flat-jni's *source* through a Gradle composite


### PR DESCRIPTION
## What this is

[zenoh-flat-jni#36](https://github.com/eclipse-zenoh/zenoh-flat-jni/pull/36) did
two things: it added a snapshot publication from `main`, and it applied
@diogomatsubara's review of that repository's CI. This repository **already has**
the publication half — snapshot from `main`, a `ci` status-check job, `rustup
show` instead of a toolchain action. What it does not have is the review half,
which is this PR.

Three concrete defects, one commit each for the first two.

## 1. Every third-party action was on a mutable major tag

`@v4`, `@v3`, `@v18` across four workflows. A tag is mutable, so a moved tag
runs code nobody reviewed — on jobs that hold the organization GPG key and the
Central token. Every third-party `uses:` now names a commit, with the version in
a trailing comment. `eclipse-zenoh/*` actions are ours and stay on a branch,
deliberately.

The pins are the **same commits zenoh-flat-jni landed**, so both halves of a
release run the same action code:

| action | pin |
| --- | --- |
| `actions/checkout` | `3d3c42e` # v7.0.1 |
| `actions/setup-java` | `b6effb0` # v5.7.0 |
| `gradle/actions/setup-gradle` | `0723195` # v5.0.2 |
| `actions/upload-artifact` | `043fb46` # v7.0.1 |
| `peaceiris/actions-gh-pages` | `84c30a8` # v4.1.0 |
| `DavidAnson/markdownlint-cli2-action` | `eb5ca3a` # v18 |

Two of those are bumps, each with its reason in place:

- **`peaceiris/actions-gh-pages` v3 → v4.1.0** — v3 runs on **node16**, a
  runtime the Actions runner has retired. Inputs unchanged (`github_token`,
  `publish_dir`).
- **`setup-gradle` v4 → v5, not v6** — v6 moved caching into a proprietary
  component under Gradle's own terms of use, which is not ours to accept for an
  Eclipse project. Same call as #36.

**`markdownlint-cli2-action` is pinned where it stands, at v18.** It is on
node20, which is not retired, and a newer major changes markdownlint's rules —
that is an upgrade to make on its own, with whatever README edits it asks for,
not inside a pinning change.

`checkout`/`setup-java`/`upload-artifact` land on current majors as a
consequence of pinning to those commits. Checked before pinning: every input
these workflows pass still exists in the pinned version, and `checkout` still
defaults `persist-credentials` to `true` — `ci/scripts/bump-and-tag.bash` pushes
the release branch and tag with those credentials.

## 2. Every branch ran CI twice, and a nightly rebuilt what the last merge built

`push` and `pull_request` were both on `["**"]`, so one commit on a branch with
an open PR meant two full runs on two runners, and two entries in the checks
list. The block now follows the main zenoh repository, and the weekday nightly
goes with it:

```yaml
push:
  branches: ["main", "release/*", "!release/dry-run/*"]
pull_request:
  branches: ["**"]
workflow_dispatch:
```

`release/*` is where a release is actually built from — the shared
`create-release-branch` action creates it — and the throwaway dry-run branches
that same action produces are excluded. Nothing loses coverage: a branch under
review is covered by `pull_request`, and a branch that is not under review had
no reader for its result. **This PR's own checks tab is the demonstration** —
one run, not two.

**The nightly is dropped.** The obvious argument for it is that it would catch
zenoh-flat-jni moving under us, and it does not — `Cargo.lock` pins that
dependency to a commit:

```text
source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#<sha>"
```

and Cargo re-resolves a git dependency only on `cargo update` or a missing lock
entry, so a timed build rebuilds exactly what the last merge built. Upstream
drift reaches this repository as a lockfile-sync pull request, which runs CI like
anything else. What a nightly would still catch is an expired Central token or
GPG key, and only during a week with no merges at all — every merge already
exercises them. That is a thin canary against a daily publication of two
coordinates, and under #525 it also risks a half-hour zenoh-flat-jni rebuild for
no new commit. `workflow_dispatch` still runs the path on demand.

This is the same call zenoh-flat-jni#36 made and recorded in its `PUBLISHING.md`;
that PR's description says the other JVM repositories keep their nightly, which
this makes stale — only zenoh-kotlin does now. Corrected there.

## 3. `release.yml` ran a dry-run release every night, and it failed every night

Its own separate `0 0 * * 1-5`. A scheduled run passes no inputs, so it passes no
`zenoh-flat-jni-version`, so it fell back to `zenohFlatJniVersion` in
`gradle.properties` — a version not on Maven Central — and died compiling:

```text
Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
```

`PUBLISHING.md` documented that failure rather than treating the schedule as the
mistake. The workflow is now `workflow_dispatch` only. Nothing is lost: a dry run
rehearses the release path, and rehearsing is as deliberate an act as the release
it rehearses — both are **Actions → Release → Run workflow**, with the version in
the box.

## 4. `PUBLISHING.md` did not say the actions were pinned

One paragraph under *How the pipeline works*, so the next person to bump one
knows it is a reviewed change rather than a version-number edit. The paragraph
that explained why the nightly release run always failed is rewritten too — that
run is gone.

## Deliberately not in scope

| From #36 | Why not |
| --- | --- |
| snapshot publish from `main`, `ci` status job, `rustup show` | already on `main` here |
| `concurrency` | **#525 adds it**, stacked on this branch, with `cancel-in-progress: false` — it publishes two coordinates from two uploads, and cancelling between them is the failure it must avoid. |
| the `release.yml` nightly dry-run release | a different schedule and a different mechanism; dropping it is its own call |
| `Swatinem/rust-cache` | no cargo step here. Gradle drives cargo inside `.zenoh-flat-jni/`, fetched *during* the build, so there is no `Cargo.lock` at restore time to key a cache on. `setup-gradle` already caches what this job reuses. |

## Verification

- No third-party action left on a tag:

  ```console
  $ git grep -n "uses:" -- .github/workflows | grep -v "eclipse-zenoh/" | grep -v "\./\.github" | grep -v " # v"
  $
  ```

- Each pin re-resolved against the API, annotated tags dereferenced — all six
  match the trailing comment.
- All six workflow files still parse.
- `setup-gradle` v5 and the pinned `checkout`/`setup-java`/markdownlint are
  exercised by this PR's own run. `actions-gh-pages` v4 is reachable only from a
  release, so it wants a **dry-run release** (`live-run: false`) before the next
  real one: the deploy step is gated on `live-run`, so the rehearsal proves the
  action resolves without touching `gh-pages`.

## Relationship to #525

**#525 is now stacked on this branch** — its base is `ci/pin-actions`, so this
one merges first and GitHub retargets it to `main` automatically. Same shape as
zenoh-flat-jni#36/#37. The rebase is done: #525 pins the four steps it adds
(`flat_jni_pin`'s checkout, and `consumer_test`'s checkout / setup-java /
setup-gradle), so `main` gets nothing unpinned, and it rewrites the three
sentences that described the nightly.

`concurrency` still belongs to that branch, with `cancel-in-progress: false` —
its pair of uploads must not be cancelled between them.
